### PR TITLE
HDDS-5391 Fix issues in SCMHAConfiguration

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -195,14 +195,6 @@ public class SCMHAConfiguration {
   )
   private long ratisRoleCheckerInterval = 15 * 1000L;
 
-  @Config(key = "ratis.snapshot.dir",
-      type = ConfigType.STRING,
-      defaultValue = "",
-      tags = {SCM, OZONE, HA, RATIS},
-      description = "The ratis snapshot dir location"
-  )
-  private String ratisSnapshotDir;
-
   @Config(key = "grpc.deadline.interval",
       type = ConfigType.TIME,
       defaultValue = "30m",
@@ -220,16 +212,8 @@ public class SCMHAConfiguration {
     return ratisStorageDir;
   }
 
-  public String getRatisSnapshotDir() {
-    return ratisSnapshotDir;
-  }
-
   public void setRatisStorageDir(String dir) {
     this.ratisStorageDir = dir;
-  }
-
-  public void setRatisSnapshotDir(String dir) {
-    this.ratisSnapshotDir = dir;
   }
 
   public void setRaftLogPurgeGap(int gap) {
@@ -312,9 +296,5 @@ public class SCMHAConfiguration {
 
   public long getRatisNodeFailureTimeout() {
     return ratisNodeFailureTimeout;
-  }
-
-  public long getRatisRoleCheckerInterval() {
-    return ratisRoleCheckerInterval;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -147,7 +147,7 @@ public final class RatisUtil {
     Log.setSegmentSizeMax(properties,
         SizeInBytes.valueOf(conf.getRaftSegmentSize()));
     Log.Appender.setBufferElementLimit(properties,
-        conf.getRaftLogAppenderQueueByteLimit());
+        conf.getRaftLogAppenderQueueNum());
     Log.Appender.setBufferByteLimit(properties,
         SizeInBytes.valueOf(conf.getRaftLogAppenderQueueByteLimit()));
     Log.setPreallocatedSize(properties,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -66,8 +66,8 @@ public class TestSCMInstallSnapshot {
     SCMHAConfiguration scmhaConfiguration = conf.getObject(
         SCMHAConfiguration.class);
     scmhaConfiguration.setRatisSnapshotThreshold(1L);
-    scmhaConfiguration.setRatisSnapshotDir(
-        GenericTestUtils.getRandomizedTempPath() + "/snapshot");
+//    scmhaConfiguration.setRatisSnapshotDir(
+//        GenericTestUtils.getRandomizedTempPath() + "/snapshot");
     conf.setFromObject(scmhaConfiguration);
     cluster = MiniOzoneCluster
         .newBuilder(conf)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -66,8 +66,6 @@ public class TestSCMInstallSnapshot {
     SCMHAConfiguration scmhaConfiguration = conf.getObject(
         SCMHAConfiguration.class);
     scmhaConfiguration.setRatisSnapshotThreshold(1L);
-//    scmhaConfiguration.setRatisSnapshotDir(
-//        GenericTestUtils.getRandomizedTempPath() + "/snapshot");
     conf.setFromObject(scmhaConfiguration);
     cluster = MiniOzoneCluster
         .newBuilder(conf)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In RatisUtils changed the call to setBufferElementLimit to use getRaftLogAppenderQueueNum as directed:
Log.Appender.setBufferElementLimit(properties,
        conf.getRaftLogAppenderQueueNum());

Removed ratis.snapshot.dir and support
Removed ratisRoleCheckerInterval and support 
All per bug directions. The only uses I found were in the one related test that was also removed in this.
Triggering a PR to get a CI test run on it. It passes my local tests. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5391

## How was this patch tested?

Manual tests have all passed. Trying to trigger a ci test run.
